### PR TITLE
replace 's.xcconfig' with 's.pod_target_xcconfig' to fix pod install warning

### DIFF
--- a/KingfisherWebP.podspec
+++ b/KingfisherWebP.podspec
@@ -24,16 +24,16 @@ KingfisherWebP is an extension of the popular library [Kingfisher](https://githu
   s.private_header_files = 'KingfisherWebP/Classes/CGImage+WebP.h'
   s.module_map = 'KingfisherWebP/KingfisherWebP.modulemap'
 
-  s.xcconfig = {
+  s.pod_target_xcconfig = {
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
   }
-  s.tvos.xcconfig = {
+  s.tvos.pod_target_xcconfig = {
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
   }
-  s.osx.xcconfig = {
+  s.osx.pod_target_xcconfig = {
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
   }
-  s.watchos.xcconfig = {
+  s.watchos.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) WEBP_USE_INTRINSICS=1',
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
   }


### PR DESCRIPTION
fix warning like： 
```
[!] Can't merge user_target_xcconfig for pod targets: ["KingfisherWebP", "XXXXX"]. Singular build setting USER_HEADER_SEARCH_PATHS has different values.
```
