### PR TITLE
Update for new generic typealias

### DIFF
--- a/KingfisherWebP/Classes/Image+WebP.swift
+++ b/KingfisherWebP/Classes/Image+WebP.swift
@@ -10,7 +10,7 @@ import Kingfisher
 import CoreGraphics
 
 // MARK: - Image Representation
-extension KingfisherWrapper where Base: Image {
+extension KingfisherWrapper where Base: KFCrossPlatformImage {
     public func webpRepresentation() -> Data? {
         if let result = animatedWebPRepresentation() {
             return result
@@ -20,7 +20,7 @@ extension KingfisherWrapper where Base: Image {
         }
         return nil
     }
-    
+
     private func animatedWebPRepresentation() -> Data? {
         #if swift(>=4.1)
         guard let images = base.images?.compactMap({ $0.cgImage }) else {
@@ -38,20 +38,20 @@ extension KingfisherWrapper where Base: Image {
 }
 
 // MARK: - Create image from WebP data
-extension KingfisherWrapper where Base: Image {
-    static func image(webpData: Data, scale: CGFloat, onlyFirstFrame: Bool) -> Image? {
+extension KingfisherWrapper where Base: KFCrossPlatformImage {
+    static func image(webpData: Data, scale: CGFloat, onlyFirstFrame: Bool) -> KFCrossPlatformImage? {
         let frameCount = WebPImageFrameCountGetFromData(webpData as CFData)
         if (frameCount == 0) {
             return nil
         }
-        
+
         if (frameCount == 1 || onlyFirstFrame) {
             guard let cgImage = WebPImageCreateWithData(webpData as CFData) else {
                 return nil
             }
-            return Image(cgImage: cgImage, scale: scale, orientation: .up)
+            return KFCrossPlatformImage(cgImage: cgImage, scale: scale, orientation: .up)
         }
-        
+
         // MARK: Animated images
         guard let animationInfo = WebPAnimatedImageInfoCreateWithData(webpData as CFData) as Dictionary? else {
             return nil
@@ -59,10 +59,10 @@ extension KingfisherWrapper where Base: Image {
         guard let cgFrames = animationInfo[kWebPAnimatedImageFrames] as? [CGImage] else {
             return nil
         }
-        let uiFrames = cgFrames.map { Image(cgImage: $0, scale: scale, orientation: .up) }
-        
+        let uiFrames = cgFrames.map { KFCrossPlatformImage(cgImage: $0, scale: scale, orientation: .up) }
+
         let duration = (animationInfo[kWebPAnimatedImageDuration] as? NSNumber).flatMap { $0.doubleValue as TimeInterval } ?? 0.1 * TimeInterval(frameCount)
-        return Image.animatedImage(with: uiFrames, duration: duration)
+        return KFCrossPlatformImage.animatedImage(with: uiFrames, duration: duration)
     }
 }
 

--- a/KingfisherWebP/Classes/WebPProcessor.swift
+++ b/KingfisherWebP/Classes/WebPProcessor.swift
@@ -17,13 +17,13 @@ public struct WebPProcessor: ImageProcessor {
 
     public init() {}
 
-    public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> Image? {
+    public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
         switch item {
         case .image(let image):
             return image
         case .data(let data):
             if data.isWebPFormat {
-                return KingfisherWrapper<Image>.image(webpData: data, scale: options.scaleFactor, onlyFirstFrame: options.onlyLoadFirstFrame)
+                return KingfisherWrapper<KFCrossPlatformImage>.image(webpData: data, scale: options.scaleFactor, onlyFirstFrame: options.onlyLoadFirstFrame)
             } else {
                 return DefaultImageProcessor.default.process(item: item, options: options)
             }

--- a/KingfisherWebP/Classes/WebPSerializer.swift
+++ b/KingfisherWebP/Classes/WebPSerializer.swift
@@ -12,7 +12,7 @@ public struct WebPSerializer: CacheSerializer {
     public static let `default` = WebPSerializer()
     private init() {}
 
-    public func data(with image: Image, original: Data?) -> Data? {
+    public func data(with image: KFCrossPlatformImage, original: Data?) -> Data? {
         if let original = original, !original.isWebPFormat {
             return DefaultCacheSerializer.default.data(with: image, original: original)
         } else {
@@ -20,7 +20,7 @@ public struct WebPSerializer: CacheSerializer {
         }
     }
 
-    public func image(with data: Data, options: KingfisherParsedOptionsInfo) -> Image? {
+    public func image(with data: Data, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
         return WebPProcessor.default.process(item: .data(data), options: options)
     }
 }


### PR DESCRIPTION
Rename too generic typealias names in Kingfisher. Original Kingfisher.Image is now Kingfisher.KFCrossPlatformImage.