### PR TITLE
Added support for quality control on WebP image

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
-  - Kingfisher (5.8.1):
-    - Kingfisher/Core (= 5.8.1)
-  - Kingfisher/Core (5.8.1)
-  - KingfisherWebP (0.6.0):
-    - Kingfisher (~> 5.0)
+  - Kingfisher (5.15.7):
+    - Kingfisher/Core (= 5.15.7)
+  - Kingfisher/Core (5.15.7)
+  - KingfisherWebP (1.0.0):
+    - Kingfisher (~> 5.8)
     - libwebp (>= 0.5.0)
-  - libwebp (1.0.3):
-    - libwebp/demux (= 1.0.3)
-    - libwebp/mux (= 1.0.3)
-    - libwebp/webp (= 1.0.3)
-  - libwebp/demux (1.0.3):
+  - libwebp (1.1.0):
+    - libwebp/demux (= 1.1.0)
+    - libwebp/mux (= 1.1.0)
+    - libwebp/webp (= 1.1.0)
+  - libwebp/demux (1.1.0):
     - libwebp/webp
-  - libwebp/mux (1.0.3):
+  - libwebp/mux (1.1.0):
     - libwebp/demux
-  - libwebp/webp (1.0.3)
+  - libwebp/webp (1.1.0)
 
 DEPENDENCIES:
   - KingfisherWebP (from `../`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - Kingfisher
     - libwebp
 
@@ -28,10 +28,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Kingfisher: de969e451c81ca6c07a454bc36fea84b8b08c3c7
-  KingfisherWebP: 53327b38511996ce093b50513abe46408a26de43
-  libwebp: 057912d6d0abfb6357d8bb05c0ea470301f5d61e
+  Kingfisher: 6e1a13523fcb1c86924ce53affe4ac957e544d59
+  KingfisherWebP: b1ed1dbc5e52547c5bf5f583dd5c46346f97320f
+  libwebp: 946cb3063cea9236285f7e9a8505d806d30e07f3
 
 PODFILE CHECKSUM: 912da7ea47a860c96d3fc41cfad2d5c868f105ec
 
-COCOAPODS: 1.7.0
+COCOAPODS: 1.10.0

--- a/KingfisherWebP/Classes/CGImage+WebP.h
+++ b/KingfisherWebP/Classes/CGImage+WebP.h
@@ -13,7 +13,7 @@ CF_ASSUME_NONNULL_BEGIN
 
 // still image
 CGImageRef __nullable WebPImageCreateWithData(CFDataRef webpData);
-CFDataRef __nullable WebPDataCreateWithImage(CGImageRef image);
+CFDataRef __nullable WebPDataCreateWithImage(CGImageRef image, BOOL isLossy, float quality);
 
 // animated image
 CG_EXTERN const CFStringRef kWebPAnimatedImageDuration;
@@ -22,7 +22,7 @@ CG_EXTERN const CFStringRef kWebPAnimatedImageFrames; // CFArrayRef of CGImageRe
 
 uint32_t WebPImageFrameCountGetFromData(CFDataRef webpData);
 CFDictionaryRef __nullable WebPAnimatedImageInfoCreateWithData(CFDataRef webpData);
-CFDataRef __nullable WebPDataCreateWithAnimatedImageInfo(CFDictionaryRef imageInfo);
+CFDataRef __nullable WebPDataCreateWithAnimatedImageInfo(CFDictionaryRef imageInfo, BOOL isLossy, float quality);
 
 CF_ASSUME_NONNULL_END
 CF_IMPLICIT_BRIDGING_DISABLED

--- a/KingfisherWebP/Classes/CGImage+WebP.m
+++ b/KingfisherWebP/Classes/CGImage+WebP.m
@@ -271,8 +271,8 @@ CGImageRef WebPImageCreateWithData(CFDataRef webpData) {
 CFDataRef WebPDataCreateWithImage(CGImageRef image, BOOL isLossy, float quality) {
     WebPConfig config;
     if (isLossy) {
-        WebPConfigInitInternal(&config, WEBP_PRESET_DEFAULT, quality, WEBP_ENCODER_ABI_VERSION);;
-    }else {
+        WebPConfigPreset(&config, WEBP_PRESET_DEFAULT, quality)
+     }else {
         WebPConfigInit(&config);
         WebPConfigLosslessPreset(&config, 0);
     }

--- a/KingfisherWebP/Classes/CGImage+WebP.m
+++ b/KingfisherWebP/Classes/CGImage+WebP.m
@@ -268,10 +268,14 @@ CGImageRef WebPImageCreateWithData(CFDataRef webpData) {
     return image;
 }
 
-CFDataRef WebPDataCreateWithImage(CGImageRef image) {
+CFDataRef WebPDataCreateWithImage(CGImageRef image, BOOL isLossy, float quality) {
     WebPConfig config;
-    WebPConfigInit(&config);
-    WebPConfigLosslessPreset(&config, 0);
+    if (isLossy) {
+        WebPConfigInitInternal(&config, WEBP_PRESET_DEFAULT, quality, WEBP_ENCODER_ABI_VERSION);;
+    }else {
+        WebPConfigInit(&config);
+        WebPConfigLosslessPreset(&config, 0);
+    }
     
     WebPPicture picture;
     WebPPictureInit(&picture);
@@ -394,7 +398,7 @@ CFDictionaryRef WebPAnimatedImageInfoCreateWithData(CFDataRef webpData) {
 
 
 
-CFDataRef WebPDataCreateWithAnimatedImageInfo(CFDictionaryRef imageInfo) {
+CFDataRef WebPDataCreateWithAnimatedImageInfo(CFDictionaryRef imageInfo, BOOL isLossy, float quality) {
     CFNumberRef loopCount = CFDictionaryGetValue(imageInfo, kWebPAnimatedImageLoopCount);
     CFNumberRef durationRef = CFDictionaryGetValue(imageInfo, kWebPAnimatedImageDuration);
     CFArrayRef imageFrames = CFDictionaryGetValue(imageInfo, kWebPAnimatedImageFrames);
@@ -427,9 +431,13 @@ CFDataRef WebPDataCreateWithAnimatedImageInfo(CFDictionaryRef imageInfo) {
         WebPPictureInit(&frame);
         if (WebPPictureImportCGImage(&frame, (CGImageRef)CFArrayGetValueAtIndex(imageFrames, i))) {
             WebPConfig config;
-            WebPConfigInit(&config);
-            WebPConfigLosslessPreset(&config, 0);
-            WebPAnimEncoderAdd(enc, &frame, (int)(frameDurationInMilliSec * i), &config);
+            if (isLossy) {
+                WebPConfigInitInternal(&config, WEBP_PRESET_DEFAULT, quality, WEBP_ENCODER_ABI_VERSION);;
+            }else {
+                WebPConfigInit(&config);
+                WebPConfigLosslessPreset(&config, 0);
+            }
+             WebPAnimEncoderAdd(enc, &frame, (int)(frameDurationInMilliSec * i), &config);
         }
         WebPPictureFree(&frame);
     }

--- a/KingfisherWebP/Classes/CGImage+WebP.m
+++ b/KingfisherWebP/Classes/CGImage+WebP.m
@@ -271,7 +271,7 @@ CGImageRef WebPImageCreateWithData(CFDataRef webpData) {
 CFDataRef WebPDataCreateWithImage(CGImageRef image, BOOL isLossy, float quality) {
     WebPConfig config;
     if (isLossy) {
-        WebPConfigPreset(&config, WEBP_PRESET_DEFAULT, quality)
+        WebPConfigPreset(&config, WEBP_PRESET_DEFAULT, quality);
      }else {
         WebPConfigInit(&config);
         WebPConfigLosslessPreset(&config, 0);
@@ -432,7 +432,7 @@ CFDataRef WebPDataCreateWithAnimatedImageInfo(CFDictionaryRef imageInfo, BOOL is
         if (WebPPictureImportCGImage(&frame, (CGImageRef)CFArrayGetValueAtIndex(imageFrames, i))) {
             WebPConfig config;
             if (isLossy) {
-                WebPConfigInitInternal(&config, WEBP_PRESET_DEFAULT, quality, WEBP_ENCODER_ABI_VERSION);;
+                WebPConfigPreset(&config, WEBP_PRESET_DEFAULT, quality);
             }else {
                 WebPConfigInit(&config);
                 WebPConfigLosslessPreset(&config, 0);

--- a/KingfisherWebP/Classes/Image+WebP.swift
+++ b/KingfisherWebP/Classes/Image+WebP.swift
@@ -16,17 +16,21 @@ import KingfisherWebP_ObjC
 
 // MARK: - Image Representation
 extension KingfisherWrapper where Base: KFCrossPlatformImage {
-    public func webpRepresentation() -> Data? {
+    /// isLossy  (0=lossy , 1=lossless (default)).
+    /// Note that the default values are isLossy= false and quality=75.0f
+    public func webpRepresentation(isLossy: Bool = false, quality: Float = 75.0) -> Data? {
         if let result = animatedWebPRepresentation() {
             return result
         }
         if let cgImage = base.cgImage {
-            return WebPDataCreateWithImage(cgImage) as Data?
+            return WebPDataCreateWithImage(cgImage, isLossy, quality) as Data?
         }
         return nil
     }
 
-    private func animatedWebPRepresentation() -> Data? {
+    /// isLossy  (0=lossy , 1=lossless (default)).
+    /// Note that the default values are isLossy= false and quality=75.0f
+    private func animatedWebPRepresentation(isLossy: Bool = false, quality: Float = 75.0) -> Data? {
         #if swift(>=4.1)
         guard let images = base.images?.compactMap({ $0.cgImage }) else {
             return nil
@@ -38,7 +42,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         #endif
         let imageInfo = [ kWebPAnimatedImageFrames: images,
                           kWebPAnimatedImageDuration: NSNumber(value: base.duration) ] as [CFString : Any]
-        return WebPDataCreateWithAnimatedImageInfo(imageInfo as CFDictionary) as Data?
+        return WebPDataCreateWithAnimatedImageInfo(imageInfo as CFDictionary, isLossy, quality) as Data?
     }
 }
 


### PR DESCRIPTION
#43 
Create a `PNG or JPEG image` to `WebP`

We can generate WebP Data following way with quality.
Compares the quality with 60% of WebP image
```
let image = UIImage(named: "test.png")
guard let data = image.kf.normalized.kf.webpRepresentation(isLossy: true, quality: 60.0) else { return }
```

Compares the quality with 85% of WebP image
```
let image = UIImage(named: "test.jpg")
guard let data = image.kf.normalized.kf.webpRepresentation(isLossy: true, quality: 85.0) else { return }

```