### PR TITLE
Bump dependencies version

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,7 @@
 PODS:
-  - Kingfisher (5.15.8):
-    - Kingfisher/Core (= 5.15.8)
-  - Kingfisher/Core (5.15.8)
-  - KingfisherWebP (1.0.0):
-    - Kingfisher (~> 5.8)
+  - Kingfisher (6.1.0)
+  - KingfisherWebP (1.1.0):
+    - Kingfisher (~> 6.1)
     - libwebp (>= 0.5.0)
   - libwebp (1.1.0):
     - libwebp/demux (= 1.1.0)
@@ -28,8 +26,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Kingfisher: a3c03d702433fa6cfedabb2bddbe076fb8f2e902
-  KingfisherWebP: b1ed1dbc5e52547c5bf5f583dd5c46346f97320f
+  Kingfisher: f5d8d60a0ef3edd642fd781bae60918599901aff
+  KingfisherWebP: 439874ba747d68059d276ea2e086549caa03896b
   libwebp: 946cb3063cea9236285f7e9a8505d806d30e07f3
 
 PODFILE CHECKSUM: 912da7ea47a860c96d3fc41cfad2d5c868f105ec

--- a/Example/Tests/KingfisherWebPTests.swift
+++ b/Example/Tests/KingfisherWebPTests.swift
@@ -23,7 +23,7 @@ class KingfisherWebPTests: XCTestCase {
         
         fileNames.forEach { fileName in
             let webpData = Data(fileName: (fileName as NSString).deletingPathExtension, extension: "webp")
-            let decodedWebP = p.process(item: .data(webpData), options: [.onlyLoadFirstFrame])
+            let decodedWebP = p.process(item: .data(webpData), options: .init([.onlyLoadFirstFrame]))
             XCTAssertNotNil(decodedWebP, fileName)
             
             let originalData = Data(fileName: fileName)
@@ -37,11 +37,11 @@ class KingfisherWebPTests: XCTestCase {
         
         animationFileNames.forEach { fileName in
             let webpData = Data(fileName: (fileName as NSString).deletingPathExtension, extension: "webp")
-            let decodedWebP = p.process(item: .data(webpData), options: [])
+            let decodedWebP = p.process(item: .data(webpData), options: .init([]))
             XCTAssertNotNil(decodedWebP, fileName)
             
             let originalData = Data(fileName: fileName)
-            let originalImage = DefaultImageProcessor.default.process(item: .data(originalData), options: [.preloadAllAnimationData])
+            let originalImage = DefaultImageProcessor.default.process(item: .data(originalData), options: .init([.preloadAllAnimationData]))
             
             XCTAssertTrue(decodedWebP?.images?.count == originalImage?.images?.count, fileName)
             
@@ -61,7 +61,7 @@ class KingfisherWebPTests: XCTestCase {
             let webpData = s.data(with: image, original: nil)
             XCTAssertNotNil(webpData, fileName)
             
-            let imageFromWebPData = s.image(with: webpData!, options: [.onlyLoadFirstFrame])
+            let imageFromWebPData = s.image(with: webpData!, options: .init([.onlyLoadFirstFrame]))
             XCTAssertNotNil(imageFromWebPData, fileName)
             
             XCTAssertTrue(image.renderEqual(to: imageFromWebPData!), fileName)
@@ -73,12 +73,12 @@ class KingfisherWebPTests: XCTestCase {
         
         animationFileNames.forEach { fileName in
             let originalData = Data(fileName: fileName)
-            let originalImage = DefaultImageProcessor.default.process(item: .data(originalData), options: [])!
+            let originalImage = DefaultImageProcessor.default.process(item: .data(originalData), options: .init([]))!
             
             let webpData = s.data(with: originalImage, original: nil)
             XCTAssertNotNil(webpData, fileName)
             
-            let imageFromWebPData = s.image(with: webpData!, options: [])
+            let imageFromWebPData = s.image(with: webpData!, options: .init([]))
             XCTAssertNotNil(imageFromWebPData, fileName)
 
             XCTAssertTrue(imageFromWebPData?.images?.count == originalImage.images?.count, fileName)
@@ -94,7 +94,7 @@ class KingfisherWebPTests: XCTestCase {
         let s = WebPSerializer.default
         let images = fileNames.compactMap { fileName -> KFCrossPlatformImage? in
             let data = Data(fileName: fileName)
-            return DefaultImageProcessor.default.process(item: .data(data), options: [])
+            return DefaultImageProcessor.default.process(item: .data(data), options: .init([]))
         }
         
         measure {
@@ -111,7 +111,7 @@ class KingfisherWebPTests: XCTestCase {
         }
         measure {
             dataList.forEach {
-                let _ = p.process(item: .data($0), options: [])
+                let _ = p.process(item: .data($0), options: .init([]))
             }
         }
     }

--- a/KingfisherWebP.podspec
+++ b/KingfisherWebP.podspec
@@ -34,7 +34,7 @@ KingfisherWebP is an extension of the popular library [Kingfisher](https://githu
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
   }
 
-  s.dependency 'Kingfisher', '~> 5.8'
+  s.dependency 'Kingfisher', '~> 6.1'
   s.dependency 'libwebp', '>= 0.5.0'
   
 end

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "KingfisherWebP", targets: ["KingfisherWebP"])
     ],
     dependencies: [
-        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "5.8.0"),
+        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "6.1.0"),
         .package(url: "https://github.com/SDWebImage/libwebp-Xcode", from: "1.0.0")
     ],
     targets: [


### PR DESCRIPTION
Refs. #46 

### What it does

Hey @Yeatse 👋 
I made this PR to bump the Kingfisher version in the podspec and SPM.

I ave a doubt about [this commit](https://github.com/Yeatse/KingfisherWebP/commit/27954fb072d6342d1b169b06f5e40f93d3ff82a5) where I had to explicitly  pass the `.init()` to avoid a compile error. If it's not necessary I will revert that commit.