### PR TITLE
Bump version and libwep dependency version

### DIFF
--- a/Example/KingfisherWebP.xcodeproj/project.pbxproj
+++ b/Example/KingfisherWebP.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACEB1AFB9204008FA782 /* KingfisherWebPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KingfisherWebPTests.swift; sourceTree = "<group>"; };
 		7B8DF0C5D391E104D17A322F /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
-		BC1668044057334C209DECF6 /* KingfisherWebP.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = KingfisherWebP.podspec; path = ../KingfisherWebP.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		BC1668044057334C209DECF6 /* KingfisherWebP.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = KingfisherWebP.podspec; path = ../KingfisherWebP.podspec; sourceTree = "<group>"; };
 		E64623EFC52785C2C626785E /* Pods-KingfisherWebP_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KingfisherWebP_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-KingfisherWebP_Tests/Pods-KingfisherWebP_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - Kingfisher (6.1.0)
-  - KingfisherWebP (1.1.0):
+  - KingfisherWebP (1.2.0):
     - Kingfisher (~> 6.1)
-    - libwebp (>= 0.5.0)
+    - libwebp (>= 1.1.0)
   - libwebp (1.1.0):
     - libwebp/demux (= 1.1.0)
     - libwebp/mux (= 1.1.0)
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Kingfisher: f5d8d60a0ef3edd642fd781bae60918599901aff
-  KingfisherWebP: 439874ba747d68059d276ea2e086549caa03896b
+  KingfisherWebP: 4354e3530c6e0aa5d1068b60eb794050d2f375cb
   libwebp: 946cb3063cea9236285f7e9a8505d806d30e07f3
 
 PODFILE CHECKSUM: 912da7ea47a860c96d3fc41cfad2d5c868f105ec

--- a/KingfisherWebP.podspec
+++ b/KingfisherWebP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KingfisherWebP'
-  s.version          = '1.1.0'
+  s.version          = '1.2.0'
   s.swift_version    = '5.0'
   s.summary          = 'A Kingfisher extension helping you process webp format'
 
@@ -35,6 +35,6 @@ KingfisherWebP is an extension of the popular library [Kingfisher](https://githu
   }
 
   s.dependency 'Kingfisher', '~> 6.1'
-  s.dependency 'libwebp', '>= 0.5.0'
+  s.dependency 'libwebp', '>= 1.1.0'
   
 end

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "6.1.0"),
-        .package(url: "https://github.com/SDWebImage/libwebp-Xcode", from: "1.0.0")
+        .package(url: "https://github.com/SDWebImage/libwebp-Xcode", from: "1.1.0")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ From Xcode 11, you can use [Swift Package Manager](https://swift.org/package-man
 You can also add KingfisherWebP using [Carthage](https://github.com/Carthage/Carthage). Note that KingfisherWebP is built on top of [libwebp](https://chromium.googlesource.com/webm/libwebp) project, so in your `Cartfile` you should add `libwebp` dependency as well:
 
 ```
-github "yeatse/KingfisherWebP" ~> 1.0.0
-github "onevcat/Kingfisher" ~> 5.8.0
-github "SDWebImage/libwebp-Xcode" ~> 1.0.0
+github "yeatse/KingfisherWebP" ~> 1.2.0
+github "onevcat/Kingfisher" ~> 6.1.0
+github "SDWebImage/libwebp-Xcode" ~> 1.1.0
 ```
 
 


### PR DESCRIPTION
## What it does
In #47 I didn't update the podspec version.

This PR updates:
• [Podspec: bump version and libwep dependency version](https://github.com/Yeatse/KingfisherWebP/commit/6874044c53b794a26af5d50afddb62519a6da221)
• [Package: bump libwep dependency version](https://github.com/Yeatse/KingfisherWebP/commit/1142aed0134fb7e3d45218c1a5e6212b3ff9dadc)
• [Update README](https://github.com/Yeatse/KingfisherWebP/commit/e101637445b4704129bf9824af0c84a278083844)
• [pod install on Example app](https://github.com/Yeatse/KingfisherWebP/commit/5bfe50f23604ee312f03cd5b972cee71bb1da8c5)

## How to test
• Test should pass
• Github check should be happy

@Yeatse I see you pushed #48 so let me know if you wanna change the Podspec version number to a different one.