### PR TITLE
Image Frame count

### DIFF
--- a/KingfisherWebP.podspec
+++ b/KingfisherWebP.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KingfisherWebP'
-  s.version          = '1.2.0'
+  s.version          = '1.3.0'
   s.swift_version    = '5.0'
   s.summary          = 'A Kingfisher extension helping you process webp format'
 
@@ -36,6 +36,6 @@ KingfisherWebP is an extension of the popular library [Kingfisher](https://githu
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
   }
 
-  s.dependency 'Kingfisher', '~> 6.1'
+  s.dependency 'Kingfisher', '~> 6.2'
   s.dependency 'libwebp', '>= 1.1.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "KingfisherWebP", targets: ["KingfisherWebP"])
     ],
     dependencies: [
-        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "6.1.0"),
+        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "6.2.0"),
         .package(url: "https://github.com/SDWebImage/libwebp-Xcode", from: "1.1.0")
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ From Xcode 11, you can use [Swift Package Manager](https://swift.org/package-man
 You can also add KingfisherWebP using [Carthage](https://github.com/Carthage/Carthage). Note that KingfisherWebP is built on top of [libwebp](https://chromium.googlesource.com/webm/libwebp) project, so in your `Cartfile` you should add `libwebp` dependency as well:
 
 ```
-github "yeatse/KingfisherWebP" ~> 1.2.0
-github "onevcat/Kingfisher" ~> 6.1.0
+github "yeatse/KingfisherWebP" ~> 1.3.0
+github "onevcat/Kingfisher" ~> 6.2.0
 github "SDWebImage/libwebp-Xcode" ~> 1.1.0
 ```
 

--- a/Sources/Image+WebP.swift
+++ b/Sources/Image+WebP.swift
@@ -62,13 +62,17 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         guard let cgImage = WebPImageCreateWithData(webpData as CFData) else {
             return nil
         }
-        return KFCrossPlatformImage(cgImage: cgImage, size: .zero)
+        let image = KFCrossPlatformImage(cgImage: cgImage, size: .zero)
+        image.kf.imageFrameCount = Int(frameCount)
+        return image
         #else
         if (frameCount == 1 || onlyFirstFrame) {
             guard let cgImage = WebPImageCreateWithData(webpData as CFData) else {
                 return nil
             }
-            return KFCrossPlatformImage(cgImage: cgImage, scale: scale, orientation: .up)
+            let image = KFCrossPlatformImage(cgImage: cgImage, scale: scale, orientation: .up)
+            image.kf.imageFrameCount = Int(frameCount)
+            return image
         }
 
         // MARK: Animated images
@@ -80,7 +84,9 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         }
         let uiFrames = cgFrames.map { KFCrossPlatformImage(cgImage: $0, scale: scale, orientation: .up) }
         let duration = (animationInfo[kWebPAnimatedImageDuration] as? NSNumber).flatMap { $0.doubleValue as TimeInterval } ?? 0.1 * TimeInterval(frameCount)
-        return KFCrossPlatformImage.animatedImage(with: uiFrames, duration: duration)
+        let image = KFCrossPlatformImage.animatedImage(with: uiFrames, duration: duration)
+        image?.kf.imageFrameCount = Int(frameCount)
+        return image
         #endif
     }
 }

--- a/Tests/KingfisherWebPTests.swift
+++ b/Tests/KingfisherWebPTests.swift
@@ -55,6 +55,8 @@ class KingfisherWebPTests: XCTestCase {
             let originalData = Data(fileName: fileName)
             let originalImage = DefaultImageProcessor.default.process(item: .data(originalData), options: .init([.onlyLoadFirstFrame]))
             
+            XCTAssertEqual(decodedWebP?.kf.imageFrameCount, originalImage?.kf.imageFrameCount)
+            
             XCTAssertTrue(decodedWebP!.renderEqual(to: originalImage!), "The first frame should be equal")
         }
     }
@@ -71,6 +73,7 @@ class KingfisherWebPTests: XCTestCase {
             let originalImage = DefaultImageProcessor.default.process(item: .data(originalData), options: .init([.preloadAllAnimationData]))
             
             XCTAssertTrue(decodedWebP?.images?.count == originalImage?.images?.count, fileName)
+            XCTAssertEqual(decodedWebP?.kf.imageFrameCount, originalImage?.kf.imageFrameCount)
             
             decodedWebP?.images?.enumerated().forEach { (index, frame) in
                 let originalFrame = originalImage!.images![index]


### PR DESCRIPTION
## What it does?
Kingfisher [#1647](https://github.com/onevcat/Kingfisher/pull/1647) introduced the `imageFrameCount` property to store the frame count value for animated image. This PR assigned the frame count value when `KFCrossPlatformImage` is created.

This PR also bump the KingfisherWebP version and refers to Kingfisher 6.2 as minimum version.

## How to test?
• CI should be happy