### PR TITLE
Update Package.swift to include KingFisherWebP_ObjC headers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
         ),
         .target(
             name: "KingfisherWebP-ObjC",
-            dependencies: ["libwebp"]
+            dependencies: ["libwebp"],
+            publicHeadersPath: "include"
         )
     ]
 )


### PR DESCRIPTION
Include headers on **Package.swift** file in order to include **KingFisherWebP_ObjC** headers

Fixes #53 