### PR TITLE
Boost performance for animated images

### DIFF
--- a/KingfisherWebP.podspec
+++ b/KingfisherWebP.podspec
@@ -36,6 +36,6 @@ KingfisherWebP is an extension of the popular library [Kingfisher](https://githu
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
   }
 
-  s.dependency 'Kingfisher', '~> 7.9'
+  s.dependency 'Kingfisher', '~> 7.11'
   s.dependency 'libwebp', '>= 1.1.0'
 end

--- a/KingfisherWebP.xcodeproj/project.pbxproj
+++ b/KingfisherWebP.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -587,7 +587,7 @@
 			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.8.0;
+				minimumVersion = 7.11.0;
 			};
 		};
 		38E23F732591BBB000EBE21D /* XCRemoteSwiftPackageReference "libwebp-Xcode" */ = {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "KingfisherWebP", targets: ["KingfisherWebP"])
     ],
     dependencies: [
-        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.8.1"),
+        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.11.0"),
         .package(url: "https://github.com/SDWebImage/libwebp-Xcode", from: "1.1.0")
     ],
     targets: [

--- a/Sources/Image+WebP.swift
+++ b/Sources/Image+WebP.swift
@@ -14,6 +14,10 @@ import Foundation
 import KingfisherWebP_ObjC
 #endif
 
+#if canImport(AppKit)
+import AppKit
+#endif
+
 // MARK: - Image Representation
 extension KingfisherWrapper where Base: KFCrossPlatformImage {
     /// isLossy  (0=lossy , 1=lossless (default)).
@@ -37,16 +41,27 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     /// isLossy  (0=lossy , 1=lossless (default)).
     /// Note that the default values are isLossy= false and quality=75.0f
     private func animatedWebPRepresentation(isLossy: Bool = false, quality: Float = 75.0) -> Data? {
-        #if os(macOS)
-        return nil
-        #else
-        guard let images = base.images?.compactMap({ $0.cgImage }) else {
+        let imageInfo: [CFString: Any]
+        if let frameSource = frameSource {
+            let frameCount = frameSource.frameCount
+            imageInfo = [
+                kWebPAnimatedImageFrames: (0..<frameCount).map({ frameSource.frame(at: $0) }),
+                kWebPAnimatedImageFrameDurations: (0..<frameCount).map({ frameSource.duration(at: $0) }),
+            ]
+        } else {
+#if os(macOS)
             return nil
+#else
+            guard let images = base.images?.compactMap({ $0.cgImage }) else {
+                return nil
+            }
+            imageInfo = [
+                kWebPAnimatedImageFrames: images,
+                kWebPAnimatedImageDuration: base.duration
+            ]
+#endif
         }
-        let imageInfo = [ kWebPAnimatedImageFrames: images,
-                          kWebPAnimatedImageDuration: NSNumber(value: base.duration) ] as [CFString : Any]
         return WebPDataCreateWithAnimatedImageInfo(imageInfo as CFDictionary, isLossy, quality) as Data?
-        #endif
     }
 }
 

--- a/Sources/KingfisherWebP-ObjC/include/CGImage+WebP.h
+++ b/Sources/KingfisherWebP-ObjC/include/CGImage+WebP.h
@@ -19,6 +19,7 @@ CFDataRef __nullable WebPDataCreateWithImage(CGImageRef image, bool isLossy, flo
 CG_EXTERN const CFStringRef kWebPAnimatedImageDuration;
 CG_EXTERN const CFStringRef kWebPAnimatedImageLoopCount;
 CG_EXTERN const CFStringRef kWebPAnimatedImageFrames; // CFArrayRef of CGImageRef
+CG_EXTERN const CFStringRef kWebPAnimatedImageFrameDurations; // CFArrayRef of CFNumberRef
 
 uint32_t WebPImageFrameCountGetFromData(CFDataRef webpData);
 CFDictionaryRef __nullable WebPAnimatedImageInfoCreateWithData(CFDataRef webpData);

--- a/Sources/WebPSerializer.swift
+++ b/Sources/WebPSerializer.swift
@@ -25,14 +25,19 @@ public struct WebPSerializer: CacheSerializer {
     private init() {}
 
     public func data(with image: KFCrossPlatformImage, original: Data?) -> Data? {
-        if let original = original, originalDataUsed {
-            return original
-        } else if let original = original, !original.isWebPFormat {
-            return DefaultCacheSerializer.default.data(with: image, original: original)
-        } else {
-            let qualityInWebp = min(max(0, compressionQuality), 1) * 100
-            return image.kf.normalized.kf.webpRepresentation(isLossy: isLossy, quality: Float(qualityInWebp))
+        if originalDataUsed {
+            if let original = original {
+                return original
+            }
+            if let frameData = image.kf.frameSource?.data {
+                return frameData
+            }
         }
+        if let original = original, !original.isWebPFormat {
+            return DefaultCacheSerializer.default.data(with: image, original: original)
+        }
+        let qualityInWebp = min(max(0, compressionQuality), 1) * 100
+        return image.kf.normalized.kf.webpRepresentation(isLossy: isLossy, quality: Float(qualityInWebp))
     }
 
     public func image(with data: Data, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {

--- a/Tests/KingfisherWebPTests.swift
+++ b/Tests/KingfisherWebPTests.swift
@@ -192,8 +192,13 @@ class KingfisherWebPTests: XCTestCase {
             XCTAssertEqual(originalFrameSource.frameCount, encodedFrameSource.frameCount)
             
             (0..<originalFrameSource.frameCount).forEach { index in
+                #if os(macOS)
                 let frame1 = KFCrossPlatformImage(cgImage: originalFrameSource.frame(at: index)!, size: .zero)
                 let frame2 = KFCrossPlatformImage(cgImage: encodedFrameSource.frame(at: index)!, size: .zero)
+                #else
+                let frame1 = KFCrossPlatformImage(cgImage: originalFrameSource.frame(at: index)!)
+                let frame2 = KFCrossPlatformImage(cgImage: encodedFrameSource.frame(at: index)!)
+                #endif
                 XCTAssertTrue(frame1.renderEqual(to: frame2), "Frame \(index) of \(fileName) should be equal")
                 
                 let duration1 = originalFrameSource.duration(at: index)

--- a/Tests/KingfisherWebPTests.swift
+++ b/Tests/KingfisherWebPTests.swift
@@ -132,7 +132,8 @@ class KingfisherWebPTests: XCTestCase {
 
     #if os(macOS)
     func testMultipleFrameEncoding() {
-        let s = WebPSerializer.default
+        var s = WebPSerializer.default
+        s.originalDataUsed = false
         
         animationFileNames.forEach { fileName in
             let originalData = Data(fileName: fileName)
@@ -149,7 +150,8 @@ class KingfisherWebPTests: XCTestCase {
     }
     #else
     func testMultipleFrameEncoding() {
-        let s = WebPSerializer.default
+        var s = WebPSerializer.default
+        s.originalDataUsed = false
         
         animationFileNames.forEach { fileName in
             let originalData = Data(fileName: fileName)
@@ -170,6 +172,59 @@ class KingfisherWebPTests: XCTestCase {
         }
     }
     #endif
+    
+    func testVariableFrameEncoding() {
+        var s = WebPSerializer.default
+        s.originalDataUsed = false
+        
+        animationFileNames.forEach { fileName in
+            let originalData = Data(fileName: fileName)
+            let originalImage = KingfisherWrapper.animatedImage(data: originalData, options: .init())!
+            
+            let webpData = s.data(with: originalImage, original: nil)
+            XCTAssertNotNil(webpData, fileName)
+            
+            let imageFromWebPData = s.image(with: webpData!, options: .init(nil))
+            XCTAssertNotNil(imageFromWebPData, fileName)
+            
+            let originalFrameSource = originalImage.kf.frameSource!
+            let encodedFrameSource = imageFromWebPData!.kf.frameSource!
+            XCTAssertEqual(originalFrameSource.frameCount, encodedFrameSource.frameCount)
+            
+            (0..<originalFrameSource.frameCount).forEach { index in
+                let frame1 = KFCrossPlatformImage(cgImage: originalFrameSource.frame(at: index)!, size: .zero)
+                let frame2 = KFCrossPlatformImage(cgImage: encodedFrameSource.frame(at: index)!, size: .zero)
+                XCTAssertTrue(frame1.renderEqual(to: frame2), "Frame \(index) of \(fileName) should be equal")
+                
+                let duration1 = originalFrameSource.duration(at: index)
+                let duration2 = encodedFrameSource.duration(at: index)
+                XCTAssertEqual(duration1, duration2, "Duration in frame \(index) of \(fileName) should be equal")
+            }
+        }
+    }
+    
+    func testOriginalDataIsUsed() {
+        let s = WebPSerializer.default
+        XCTAssertTrue(s.originalDataUsed)
+        
+        let randomData = Data((0..<10).map { _ in UInt8.random(in: 0...255) })
+        let encoded = s.data(with: KFCrossPlatformImage(), original: randomData)
+        XCTAssertEqual(encoded, randomData, "Original data should be used")
+        
+        struct RandomFrameSource: ImageFrameSource {
+            let data: Data? = Data((0..<10).map { _ in UInt8.random(in: 0...255) })
+            let frameCount: Int = 10
+            func duration(at index: Int) -> TimeInterval { return 0 }
+            func frame(at index: Int, maxSize: CGSize?) -> CGImage? {
+                KFCrossPlatformImage(data: .init(fileName: "cover.png"))?.kfCGImage
+            }
+        }
+        
+        let source = RandomFrameSource()
+        let image = KingfisherWrapper.animatedImage(source: source, options: .init())!
+        let encoded2 = s.data(with: image, original: nil)
+        XCTAssertEqual(encoded2, source.data, "Original data should be used")
+    }
     
     func testEncodingPerformance() {
         let s = WebPSerializer.default


### PR DESCRIPTION
1. Cache decoded frames to avoid decoding multiple times
2. Avoid unneeded encoding when serializing to local cache
3. Support encoding frames in variable durations