### PR TITLE
Improve WebP Format Detection in Data Extension

### DIFF
--- a/Sources/Image+WebP.swift
+++ b/Sources/Image+WebP.swift
@@ -175,16 +175,12 @@ extension Data {
             return false
         }
 
-        let endIndex = index(startIndex, offsetBy: 12)
-        let testData = subdata(in: startIndex..<endIndex)
-        guard let testString = String(data: testData, encoding: .ascii) else {
-            return false
-        }
+        let riffHeader = subdata(in: startIndex..<index(startIndex, offsetBy: 4))
+        let webpHeader = subdata(in: index(startIndex, offsetBy: 8)..<index(startIndex, offsetBy: 12))
 
-        if testString.hasPrefix("RIFF") && testString.hasSuffix("WEBP") {
-            return true
-        } else {
-            return false
-        }
+        let riffString = String(data: riffHeader, encoding: .ascii)
+        let webpString = String(data: webpHeader, encoding: .ascii)
+
+        return riffString == "RIFF" && webpString == "WEBP"
     }
 }


### PR DESCRIPTION
The PR fixes an issue where some WebP Images particularly animated ones, were not properly detected due to an incorrect format check.

Now it ensures a more accurate identification of WebP images by separately checking the RIFF (0-4 bytes) and WEBP header (8-12) bytes to allow a better handling of different WebP variants.