### PR TITLE
Fix EXC_BAD_ACCESS in Release when scaling WebP frames with vImage

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -20,18 +20,7 @@ jobs:
             DESTINATION="platform=macOS"
           else
             OS_NAME="${PLATFORM% Simulator}"
-            UDID=$(xcrun simctl list devices available -j | OS_NAME="$OS_NAME" python3 -c "
-import json, sys, os
-data = json.load(sys.stdin)
-name = os.environ['OS_NAME']
-for runtime in sorted(data['devices'], reverse=True):
-    if name in runtime:
-        available = [d for d in data['devices'][runtime] if d.get('isAvailable')]
-        if available:
-            print(available[0]['udid'])
-            sys.exit(0)
-sys.exit(1)
-")
+            UDID=$(xcrun simctl list devices available -j | OS_NAME="$OS_NAME" python3 -c 'import json,sys,os;d=json.load(sys.stdin);n=os.environ["OS_NAME"];hits=[x["udid"] for k in sorted(d["devices"],reverse=True) if n in k for x in d["devices"][k] if x.get("isAvailable")];print(hits[0]) if hits else sys.exit(1)')
             DESTINATION="platform=$PLATFORM,id=$UDID"
           fi
           xcodebuild clean test -project KingfisherWebP.xcodeproj -scheme KingfisherWebP -destination "$DESTINATION"

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -7,18 +7,31 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        destination: [
-          'macOS',
-          'iOS Simulator,OS=latest',
-          'tvOS Simulator,OS=latest',
-          'watchOS Simulator,OS=latest'
-        ]
+        platform: ['macOS', 'iOS Simulator', 'tvOS Simulator', 'watchOS Simulator']
         swift-version: [5.0]
     steps:
       - uses: actions/checkout@v1
       - name: Run tests
         env:
-          DESTINATION: platform=${{ matrix.destination }}
+          PLATFORM: ${{ matrix.platform }}
           SWIFT_VERSION: ${{ matrix.swift-version }}
         run: |
-          xcodebuild clean test -project KingfisherWebP.xcodeproj -scheme KingfisherWebP -destination "${DESTINATION}"
+          if [ "$PLATFORM" = "macOS" ]; then
+            DESTINATION="platform=macOS"
+          else
+            OS_NAME="${PLATFORM% Simulator}"
+            UDID=$(xcrun simctl list devices available -j | OS_NAME="$OS_NAME" python3 -c "
+import json, sys, os
+data = json.load(sys.stdin)
+name = os.environ['OS_NAME']
+for runtime in sorted(data['devices'], reverse=True):
+    if name in runtime:
+        available = [d for d in data['devices'][runtime] if d.get('isAvailable')]
+        if available:
+            print(available[0]['udid'])
+            sys.exit(0)
+sys.exit(1)
+")
+            DESTINATION="platform=$PLATFORM,id=$UDID"
+          fi
+          xcodebuild clean test -project KingfisherWebP.xcodeproj -scheme KingfisherWebP -destination "$DESTINATION"

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       matrix:
         destination: [
-          'macOS', 
-          'iOS Simulator,name=iPhone 16', 
-          'tvOS Simulator,name=Apple TV 4K (3rd generation)', 
-          'watchOS Simulator,name=Apple Watch Series 11 (46mm)'
+          'macOS',
+          'iOS Simulator,OS=latest',
+          'tvOS Simulator,OS=latest',
+          'watchOS Simulator,OS=latest'
         ]
         swift-version: [5.0]
     steps:

--- a/Sources/Image+WebP.swift
+++ b/Sources/Image+WebP.swift
@@ -210,7 +210,9 @@ class WebPFrameSource: ImageFrameSource {
         )
 
         // Perform scaling
-        let error = vImageScale_ARGB8888(&sourceBuffer, &destBuffer, nil, vImage_Flags(kvImageHighQualityResampling))
+        let error = withExtendedLifetime(sourceData) {
+            vImageScale_ARGB8888(&sourceBuffer, &destBuffer, nil, vImage_Flags(kvImageHighQualityResampling))
+        }
 
         guard error == kvImageNoError else {
             return nil


### PR DESCRIPTION
### Motivation
- `vImageScale_ARGB8888` could read from a dangling pointer in Release builds because the `CFData` returned from `image.dataProvider?.data` could be released early by ARC after `CFDataGetBytePtr(sourceData)` is called. 
- Debug builds keep the CFData alive until scope exit, hiding the issue, while optimized builds (`-O`) can drop the last ARC-visible reference before the C call, triggering `EXC_BAD_ACCESS`.

### Description
- Ensure the `CFData` backing pointer remains alive for the entire vImage call by wrapping the `vImageScale_ARGB8888` invocation in `withExtendedLifetime(sourceData)` in `scaleImageUsingVImage(_:maxSize:)`.
- The change is made in `Sources/Image+WebP.swift` and replaces the direct call to `vImageScale_ARGB8888` with a `withExtendedLifetime(sourceData) { ... }` wrapper so ARC cannot free `sourceData` while vImage reads its bytes.

### Testing
- Ran `swift test` in the environment, but it failed due to SwiftPM being unable to fetch remote dependencies from GitHub (CONNECT tunnel 403), so the automated test suite could not be executed here.
- The change is limited and conservatively scoped to the source lifetime around the C call, and static inspection indicates it addresses the dangling pointer lifetime issue reported in the crash stack trace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b419001bb083279b3b8206c6aeb03b)