### PR TITLE
Fix EXC_BAD_ACCESS in scaleImageUsingVImage due to ARC premature release of sourceData

### DIFF
--- a/Sources/Image+WebP.swift
+++ b/Sources/Image+WebP.swift
@@ -184,58 +184,61 @@ class WebPFrameSource: ImageFrameSource {
             return nil
         }
 
-        var sourceBuffer = vImage_Buffer(
-            data: UnsafeMutableRawPointer(mutating: sourceBytes),
-            height: vImagePixelCount(sourceHeight),
-            width: vImagePixelCount(sourceWidth),
-            rowBytes: image.bytesPerRow
-        )
+        // Ensure sourceData stays alive while vImage reads from its buffer.
+        // Without this, ARC may release sourceData after CFDataGetBytePtr (its last
+        // direct use), causing vImageScale_ARGB8888 to read from freed memory.
+        return withExtendedLifetime(sourceData) { () -> CGImage? in
+            var sourceBuffer = vImage_Buffer(
+                data: UnsafeMutableRawPointer(mutating: sourceBytes),
+                height: vImagePixelCount(sourceHeight),
+                width: vImagePixelCount(sourceWidth),
+                rowBytes: image.bytesPerRow
+            )
 
-        // Create destination buffer
-        let destBytesPerRow = targetWidth * bytesPerPixel
-        let destDataSize = targetHeight * destBytesPerRow
-        guard let destData = CFDataCreateMutable(kCFAllocatorDefault, destDataSize) else {
-            return nil
+            // Create destination buffer
+            let destBytesPerRow = targetWidth * bytesPerPixel
+            let destDataSize = targetHeight * destBytesPerRow
+            guard let destData = CFDataCreateMutable(kCFAllocatorDefault, destDataSize) else {
+                return nil
+            }
+            CFDataSetLength(destData, destDataSize)
+
+            guard let destBytes = CFDataGetMutableBytePtr(destData) else {
+                return nil
+            }
+            var destBuffer = vImage_Buffer(
+                data: destBytes,
+                height: vImagePixelCount(targetHeight),
+                width: vImagePixelCount(targetWidth),
+                rowBytes: destBytesPerRow
+            )
+
+            // Perform scaling
+            let error = vImageScale_ARGB8888(&sourceBuffer, &destBuffer, nil, vImage_Flags(kvImageHighQualityResampling))
+
+            guard error == kvImageNoError else {
+                return nil
+            }
+
+            // Create CGImage from destination buffer
+            guard let dataProvider = CGDataProvider(data: destData) else {
+                return nil
+            }
+
+            return CGImage(
+                width: targetWidth,
+                height: targetHeight,
+                bitsPerComponent: bitsPerComponent,
+                bitsPerPixel: image.bitsPerPixel,
+                bytesPerRow: destBytesPerRow,
+                space: colorSpace,
+                bitmapInfo: bitmapInfo,
+                provider: dataProvider,
+                decode: nil,
+                shouldInterpolate: true,
+                intent: .defaultIntent
+            )
         }
-        CFDataSetLength(destData, destDataSize)
-
-        guard let destBytes = CFDataGetMutableBytePtr(destData) else {
-            return nil
-        }
-        var destBuffer = vImage_Buffer(
-            data: destBytes,
-            height: vImagePixelCount(targetHeight),
-            width: vImagePixelCount(targetWidth),
-            rowBytes: destBytesPerRow
-        )
-
-        // Perform scaling
-        let error = vImageScale_ARGB8888(&sourceBuffer, &destBuffer, nil, vImage_Flags(kvImageHighQualityResampling))
-
-        guard error == kvImageNoError else {
-            return nil
-        }
-
-        // Create CGImage from destination buffer
-        guard let dataProvider = CGDataProvider(data: destData) else {
-            return nil
-        }
-
-        let scaledImage = CGImage(
-            width: targetWidth,
-            height: targetHeight,
-            bitsPerComponent: bitsPerComponent,
-            bitsPerPixel: image.bitsPerPixel,
-            bytesPerRow: destBytesPerRow,
-            space: colorSpace,
-            bitmapInfo: bitmapInfo,
-            provider: dataProvider,
-            decode: nil,
-            shouldInterpolate: true,
-            intent: .defaultIntent
-        )
-
-        return scaledImage
     }
 
     private func scaleImageUsingContext(_ image: CGImage, maxSize: CGSize) -> CGImage? {


### PR DESCRIPTION
## Problem

In release builds with compiler optimizations enabled, Swift's ARC optimizer may insert an early release for `sourceData` (CFData) right after `CFDataGetBytePtr` — its last direct use — before `vImageScale_ARGB8888` finishes reading from the buffer.

Since the raw pointer (`UnsafeMutableRawPointer`) obtained from `CFDataGetBytePtr` does not participate in ARC, the pointer becomes dangling once `sourceData` is released. This causes **EXC_BAD_ACCESS** crashes during animated WebP frame scaling.

**Crash stack:**
```
Animator.preloadQueue:
  vImageScale_ARGB8888
  → WebPFrameSource.scaleImageUsingVImage (Image+WebP.swift:215)
  → WebPFrameSource.frame(at:maxSize:) (Image+WebP.swift:146)
  → AnimatedImageView.Animator.updatePreloadedFrames() (AnimatedImageView.swift:726)
```

## Fix

Wrap the vImage scaling operation in `withExtendedLifetime(sourceData)` to ensure the backing CFData stays alive for the entire duration of the scaling operation.

This is a well-known Swift/ARC pattern for keeping objects alive when only raw pointers are used downstream. See: [Swift documentation on withExtendedLifetime](https://developer.apple.com/documentation/swift/withextendedlifetime(_:_:)-6gxw1)

## Impact

- Fixes intermittent `EXC_BAD_ACCESS` crashes when displaying animated WebP images at non-native sizes
- No behavioral change — only ensures correct object lifetime
- No API changes

Ref: #95