### PR TITLE
Align animated WebP frame rows and reduce phys footprint

### DIFF
--- a/Sources/KingfisherWebP-ObjC/CGImage+WebP.m
+++ b/Sources/KingfisherWebP-ObjC/CGImage+WebP.m
@@ -631,9 +631,52 @@ anim_decoder:
     if (!imageData) {
         return NULL;
     }
-    CGDataProviderRef provider = CGDataProviderCreateWithCFData(imageData);
-    CGImageRef image = CGImageCreate(info.canvas_width, info.canvas_height, 8, 32, info.canvas_width * 4, WebPColorSpaceForDeviceRGB(), kCGImageAlphaPremultipliedLast | kCGBitmapByteOrderDefault, provider, NULL, false, kCGRenderingIntentDefault);
-    CGDataProviderRelease(provider);
+
+    const size_t srcStride = info.canvas_width * 4;
+    const size_t alignedBytesPerRow = ((srcStride + 31) / 32) * 32;
+    const size_t alignedBufSize = alignedBytesPerRow * info.canvas_height;
+    void *alignedBuf = malloc(alignedBufSize);
+    if (!alignedBuf) {
+        CFRelease(imageData);
+        return NULL;
+    }
+    const uint8_t *src = CFDataGetBytePtr(imageData);
+    for (int y = 0; y < info.canvas_height; y++) {
+        memcpy((uint8_t *)alignedBuf + y * alignedBytesPerRow, src + y * srcStride, srcStride);
+    }
     CFRelease(imageData);
+    imageData = NULL;
+
+    CGColorSpaceRef colorSpace = WebPColorSpaceForDeviceRGB();
+    CGContextRef ctx = CGBitmapContextCreate(NULL,
+                                             info.canvas_width,
+                                             info.canvas_height,
+                                             8,
+                                             alignedBytesPerRow,
+                                             colorSpace,
+                                             kCGImageAlphaPremultipliedLast | kCGBitmapByteOrderDefault);
+    if (!ctx) {
+        free(alignedBuf);
+        return NULL;
+    }
+    void *dstData = CGBitmapContextGetData(ctx);
+    if (!dstData) {
+        CGContextRelease(ctx);
+        free(alignedBuf);
+        return NULL;
+    }
+
+    uint8_t *dst = (uint8_t *)dstData;
+    for (int y = 0; y < info.canvas_height; y++) {
+        memcpy(dst + y * alignedBytesPerRow, (uint8_t *)alignedBuf + y * alignedBytesPerRow, alignedBytesPerRow);
+    }
+
+    free(alignedBuf);
+
+    CGImageRef image = CGBitmapContextCreateImage(ctx);
+    CGContextRelease(ctx);
+    if (!image) {
+        return NULL;
+    }
     return image;
 }

--- a/Sources/KingfisherWebP-ObjC/CGImage+WebP.m
+++ b/Sources/KingfisherWebP-ObjC/CGImage+WebP.m
@@ -635,7 +635,7 @@ anim_decoder:
     const size_t srcStride = info.canvas_width * 4;
     const size_t alignedBytesPerRow = ((srcStride + 31) / 32) * 32;
     const size_t alignedBufSize = alignedBytesPerRow * info.canvas_height;
-    void *alignedBuf = malloc(alignedBufSize);
+    void *alignedBuf = calloc(1, alignedBufSize);
     if (!alignedBuf) {
         CFRelease(imageData);
         return NULL;

--- a/Sources/KingfisherWebP-ObjC/CGImage+WebP.m
+++ b/Sources/KingfisherWebP-ObjC/CGImage+WebP.m
@@ -634,18 +634,6 @@ anim_decoder:
 
     const size_t srcStride = info.canvas_width * 4;
     const size_t alignedBytesPerRow = ((srcStride + 31) / 32) * 32;
-    const size_t alignedBufSize = alignedBytesPerRow * info.canvas_height;
-    void *alignedBuf = calloc(1, alignedBufSize);
-    if (!alignedBuf) {
-        CFRelease(imageData);
-        return NULL;
-    }
-    const uint8_t *src = CFDataGetBytePtr(imageData);
-    for (int y = 0; y < info.canvas_height; y++) {
-        memcpy((uint8_t *)alignedBuf + y * alignedBytesPerRow, src + y * srcStride, srcStride);
-    }
-    CFRelease(imageData);
-    imageData = NULL;
 
     CGColorSpaceRef colorSpace = WebPColorSpaceForDeviceRGB();
     CGContextRef ctx = CGBitmapContextCreate(NULL,
@@ -656,27 +644,26 @@ anim_decoder:
                                              colorSpace,
                                              kCGImageAlphaPremultipliedLast | kCGBitmapByteOrderDefault);
     if (!ctx) {
-        free(alignedBuf);
+        CFRelease(imageData);
         return NULL;
     }
-    void *dstData = CGBitmapContextGetData(ctx);
-    if (!dstData) {
+
+    uint8_t *dst = (uint8_t *)CGBitmapContextGetData(ctx);
+    if (!dst) {
         CGContextRelease(ctx);
-        free(alignedBuf);
+        CFRelease(imageData);
         return NULL;
     }
 
-    uint8_t *dst = (uint8_t *)dstData;
-    for (int y = 0; y < info.canvas_height; y++) {
-        memcpy(dst + y * alignedBytesPerRow, (uint8_t *)alignedBuf + y * alignedBytesPerRow, alignedBytesPerRow);
+    // Direct copy from imageData to CGBitmapContext buffer (no intermediate buffer)
+    const uint8_t *src = CFDataGetBytePtr(imageData);
+    for (uint32_t y = 0; y < info.canvas_height; y++) {
+        memcpy(dst + y * alignedBytesPerRow, src + y * srcStride, srcStride);
     }
 
-    free(alignedBuf);
-
+    CFRelease(imageData);
     CGImageRef image = CGBitmapContextCreateImage(ctx);
     CGContextRelease(ctx);
-    if (!image) {
-        return NULL;
-    }
+    
     return image;
 }


### PR DESCRIPTION
WebPDecoderCopyImageAtIndex now copies decoded RGBA into a 32-byte-aligned bytes-per-row buffer and builds the CGImage via CGBitmapContext instead of CGDataProvider-on-CFData, lowering physical memory footprint for decoded frames.

Test / demo: https://github.com/lijingpei2016/WebPImageDemo